### PR TITLE
Add support for insert or update persons

### DIFF
--- a/cf-arctic.php
+++ b/cf-arctic.php
@@ -335,7 +335,12 @@ EOT;
 		// RUN
 		try {
 			// save
-			$person->insert();
+			if (isset($config['attempt_update']) && $config['attempt_update']) {
+				$person->insertOrUpdate();
+			}
+			else {
+				$person->insert();
+			}
 			self::_inserted_model_store('person', $person);
 
 			// return success

--- a/config-person.php
+++ b/config-person.php
@@ -135,7 +135,7 @@
 <div class="caldera-config-group">
     <label><?php echo __('Attempt Update', 'cf-slack'); ?> </label>
     <div class="caldera-config-field">
-        <label><input type="checkbox" class="field-config" name="{{_name}}[attempt_update]" id="{{_id}}_attempt_update" value="1" {{#if attempt_update}}checked="checked"{{/if}}> Update existing customer if potential duplicate</label>
-        <p class="description"><?php __('Recommended. By default, always Arctic creates a new customer record. If checked, Arctic will look for a close match (based on name, email address and phone number), and update the existing entry instead.', 'cf-arctic'); ?></p>
+        <label><input type="checkbox" class="field-config" name="{{_name}}[attempt_update]" id="{{_id}}_attempt_update" value="1" {{#if attempt_update}}checked="checked"{{/if}}> Update existing person if potential duplicate</label>
+        <p class="description"><?php echo __('Recommended. By default, always Arctic creates a new person record. If checked, Arctic will look for a close match (based on name, email address and phone number), and update the existing entry instead.', 'cf-arctic'); ?></p>
     </div>
 </div>

--- a/config-person.php
+++ b/config-person.php
@@ -129,3 +129,13 @@
 		</div>
 	</div>
 <?php } ?>
+
+<h4>Settings</h4>
+
+<div class="caldera-config-group">
+    <label><?php echo __('Attempt Update', 'cf-slack'); ?> </label>
+    <div class="caldera-config-field">
+        <label><input type="checkbox" class="field-config" name="{{_name}}[attempt_update]" id="{{_id}}_attempt_update" value="1" {{#if attempt_update}}checked="checked"{{/if}}> Update existing customer if potential duplicate</label>
+        <p class="description"><?php __('Recommended. By default, always Arctic creates a new customer record. If checked, Arctic will look for a close match (based on name, email address and phone number), and update the existing entry instead.', 'cf-arctic'); ?></p>
+    </div>
+</div>


### PR DESCRIPTION
A new option on the “create person” processor causes Arctic to look for potential duplicates. If one is found, the new form data is merged into that record. If not, a new record is created. This helps reduce duplicate records and the option is recommended.

Closes #2.

Merge once the API is finalized:

https://github.com/arcticres/arctic-api/pull/6